### PR TITLE
typo:  timelime -> timeline

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/TimelineObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TimelineObserver.groovy
@@ -73,7 +73,7 @@ class TimelineObserver implements TraceObserver {
     void onFlowCreate(Session session) {
         beginMillis = startMillis = System.currentTimeMillis()
         if( Files.exists(reportFile) && !overwrite )
-            throw new AbortOperationException("Timeline file already exists: ${reportFile.toUriString()} -- enable the 'timelime.overwrite' option in your config file to overwrite existing files")
+            throw new AbortOperationException("Timeline file already exists: ${reportFile.toUriString()} -- enable the 'timeline.overwrite' option in your config file to overwrite existing files")
     }
 
     /**


### PR DESCRIPTION
fix a typo for a message giving a wrong advice : 
```
enable the 'timelime.overwrite' option in your config 
```

to

````
enable the 'timeline.overwrite' option in your config 
```